### PR TITLE
Add OracleLib library and update PamojaFi contract for Chainlink Oracle data checking

### DIFF
--- a/contracts/script/DeployPamojaFi.s.sol
+++ b/contracts/script/DeployPamojaFi.s.sol
@@ -1,0 +1,9 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+
+contract DeployPamojaFi is Script {
+    function setUp() public {}
+}

--- a/contracts/src/libraries/OracleLib.sol
+++ b/contracts/src/libraries/OracleLib.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+/*
+ * @title OracleLib
+ * @author Patrick Collins
+ * @notice This library is used to check the Chainlink Oracle for stale data.
+ *
+ *
+ * if the Chainlink network explodes and you have a lot of money locked in the protocol... too bad.
+ */
+
+library OracleLib {
+    error OracleLib__StalePrice();
+
+    uint256 public constant TIMEOUT = 24 hours;
+
+    function checkStaleTime(
+        AggregatorV3Interface chainlinkFeed
+    ) public view returns (uint256) {
+        (, , , uint256 updatedAt, ) = chainlinkFeed.latestRoundData();
+        uint256 secondsSince = block.timestamp - updatedAt;
+        return secondsSince;
+    }
+
+    function checkLatestRoundData(
+        AggregatorV3Interface chainlinkFeed
+    ) public view returns (uint80, int256, uint256, uint256, uint80) {
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = chainlinkFeed.latestRoundData();
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function staleCheckLatestRoundData(
+        AggregatorV3Interface chainlinkFeed
+    ) public view returns (uint80, int256, uint256, uint256, uint80) {
+        (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = chainlinkFeed.latestRoundData();
+
+        if (updatedAt == 0 || answeredInRound < roundId) {
+            revert OracleLib__StalePrice();
+        }
+        uint256 secondsSince = block.timestamp - updatedAt;
+        if (secondsSince > TIMEOUT) revert OracleLib__StalePrice();
+
+        return (roundId, answer, startedAt, updatedAt, answeredInRound);
+    }
+
+    function getTimeout(
+        AggregatorV3Interface /* chainlinkFeed */
+    ) public pure returns (uint256) {
+        return TIMEOUT;
+    }
+}

--- a/contracts/test/SmartContractOrderGuide.sol
+++ b/contracts/test/SmartContractOrderGuide.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.20;
+
+// Layout of Contract:
+// version
+// imports
+// errors
+// interfaces, libraries, contracts
+// Type declarations
+// State variables
+// Events
+// Modifiers
+// Functions
+
+// Layout of Functions:
+// constructor
+// receive function (if exists)
+// fallback function (if exists)
+// external
+// public
+// internal
+// private
+// view & pure functions


### PR DESCRIPTION
This pull request adds the OracleLib library to the contracts/src/libraries directory. The library provides functions for checking the freshness of data from a Chainlink Oracle, including checking the time since the last update, retrieving the latest round data, and performing a stale check on the data. Additionally, the PamojaFi contract in the contracts/src/PamojaFi.sol file is updated to use the OracleLib library for checking the Chainlink Oracle data. This update enhances the accuracy and reliability of the price feed data in the contract.