### PR TITLE
Add deployment scripts for ERC4626C and PamojaFi contracts

### DIFF
--- a/contracts/script/DeployERC4626C.s.sol
+++ b/contracts/script/DeployERC4626C.s.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+import {ERC4626C} from "../src/ERC4626C.sol";
+
+contract DeployERC4626C is Script {
+    function run() external {
+        vm.startBroadcast();
+
+        // Deploy the ERC4626C contract
+        ERC4626C erc4626c = new ERC4626C();
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/script/DeployPamojaFi.s.sol
+++ b/contracts/script/DeployPamojaFi.s.sol
@@ -3,7 +3,22 @@
 pragma solidity ^0.8.20;
 
 import {Script} from "forge-std/Script.sol";
+import {PamojaFi} from "../src/PamojaFi.sol";
+import {console} from "forge-std/console.sol";
+
 
 contract DeployPamojaFi is Script {
     function setUp() public {}
+
+    function run() external {
+        // Start broadcasting transactions
+        vm.startBroadcast();
+
+        //Chainlink price feed address for Base network
+        address priceFeedAddress = 0x4aDC67696bA383F43DD60A9e78F2C97Fbbfc7cb1;      
+        PamojaFi pamojaFi = new PamojaFi(priceFeedAddress);
+        console.log("PamojaFi deployed at: ", address(pamojaFi));
+        // Stop broadcasting transactions
+        vm.stopBroadcast();
+    }
 }


### PR DESCRIPTION
- Added DeployPamojaFi.s.sol script to deploy the PamojaFi contract.
- The script includes setup for broadcasting transactions and deployment of the PamojaFi contract with a Chainlink price feed address.



Co-authored-by: Dancan254 <dancanian25@gmail.com>